### PR TITLE
sbt-pgp: 2.2.1 -> 2.3.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.12.1")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.12.0")


### PR DESCRIPTION
📦 Updates [com.github.sbt:sbt-pgp](https://github.com/sbt/sbt-pgp) from `2.2.1` to `2.3.0`

📜 [GitHub Release Notes](https://github.com/sbt/sbt-pgp/releases/tag/v2.3.0) - [Version Diff](https://github.com/sbt/sbt-pgp/compare/v2.2.1...v2.3.0)