### PR TITLE
Use BufferedOutput for forked JVM output strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ Create a .war file with `package`:
 > package
 ```
 
-## Settings and commands
+## Settings
 
-| Setting Key                     | Type               | Default           | Notes                                                                                   |
+| Key                             | Type               | Default           | Notes                                                                                   |
 | ------------------------------- | ------------------ | ----------------- | --------------------------------------------------------------------------------------- |
 | `webappResources`               | `Map[String,File]` | *src/main/webapp* | Static files (HTML, CSS, JS, images, etc.) to serve directly                            |
 | `webappClasses`                 | `Map[String,File]` | project classes   | .class files to copy into the *WEB-INF/classes* directory                               |
@@ -125,10 +125,12 @@ Create a .war file with `package`:
 | `webappComponentsRunnerVersion` | `String`           | `"10.1.28.0-M1"`  | The version of `com.earldouglas:webapp-components-runner` to use for running the webapp |
 | `webappPort`                    | `Int`              | `8080`            | The local container port to use when running with `webappStart`                         |
 | `warPort`                       | `Int`              | `8080`            | The local container port to use when running with `warStart`                            |
-| `webappForkOptions`             | `ForkOptions`      | `ForkOptions()`   | Options for the forked JVM used when running with `webappStart`                         |
-| `warForkOptions`                | `ForkOptions`      | `ForkOptions()`   | Options for the forked JVM used when running with `warStart`                            |
+| `webappForkOptions`             | `ForkOptions`      | Buffered output   | Options for the forked JVM used when running with `webappStart`                         |
+| `warForkOptions`                | `ForkOptions`      | Buffered output   | Options for the forked JVM used when running with `warStart`                            |
 
-| Task Key      | Notes                                                                   |
+## Commands
+
+| Key           | Notes                                                                   |
 | ------------- | ----------------------------------------------------------------------- |
 | `warStart`    | Starts a local container, serving content from the packaged .war file   |
 | `warJoin`     | Blocks until the container shuts down                                   |

--- a/src/main/scala/com/earldouglas/sbt/war/WarPackageRunnerPlugin.scala
+++ b/src/main/scala/com/earldouglas/sbt/war/WarPackageRunnerPlugin.scala
@@ -21,7 +21,7 @@ object WarPackageRunnerPlugin extends AutoPlugin {
     lazy val warJoin = taskKey[Unit]("join war container")
     lazy val warStop = taskKey[Unit]("stop war container")
     lazy val warForkOptions =
-      settingKey[ForkOptions]("war container fork options")
+      taskKey[ForkOptions]("war container fork options")
   }
 
   import autoImport._
@@ -94,15 +94,25 @@ object WarPackageRunnerPlugin extends AutoPlugin {
           }
       }
 
+    val forkOptions: Initialize[Task[ForkOptions]] =
+      Def.task {
+        ForkOptions()
+          .withOutputStrategy(Some(BufferedOutput(streams.value.log)))
+      }
+
+    val runnerLibrary: Initialize[ModuleID] =
+      Def.setting {
+        ("com.heroku" % "webapp-runner" % webappRunnerVersion.value intransitive ()) % War
+      }
+
     Seq(
       warPort := 8080,
       warStart := startWar.value,
       warJoin := joinWar.value,
       warStop := stopWar.value,
-      warForkOptions := ForkOptions(),
+      warForkOptions := forkOptions.value,
       Global / onLoad := onLoadSetting.value,
-      libraryDependencies +=
-        ("com.heroku" % "webapp-runner" % webappRunnerVersion.value intransitive ()) % War
+      libraryDependencies += runnerLibrary.value
     )
   }
 }

--- a/src/main/scala/com/earldouglas/sbt/war/WebappComponentsRunnerPlugin.scala
+++ b/src/main/scala/com/earldouglas/sbt/war/WebappComponentsRunnerPlugin.scala
@@ -23,7 +23,7 @@ object WebappComponentsRunnerPlugin extends AutoPlugin {
     lazy val webappJoin = taskKey[Unit]("join webapp container")
     lazy val webappStop = taskKey[Unit]("stop webapp container")
     lazy val webappForkOptions =
-      settingKey[ForkOptions]("webapp container fork options")
+      taskKey[ForkOptions]("webapp container fork options")
     lazy val webappComponentsRunnerVersion =
       settingKey[String]("webapp-components-runner version")
   }
@@ -106,6 +106,12 @@ object WebappComponentsRunnerPlugin extends AutoPlugin {
     val stopWebapp: Initialize[Task[Unit]] =
       Def.task(stopContainerInstance())
 
+    val forkOptions: Initialize[Task[ForkOptions]] =
+      Def.task {
+        ForkOptions()
+          .withOutputStrategy(Some(BufferedOutput(streams.value.log)))
+      }
+
     val onLoadSetting: Initialize[State => State] =
       Def.setting {
         (Global / onLoad).value
@@ -127,7 +133,7 @@ object WebappComponentsRunnerPlugin extends AutoPlugin {
       webappStart := startWebapp.value,
       webappJoin := joinWebapp.value,
       webappStop := stopWebapp.value,
-      webappForkOptions := ForkOptions(),
+      webappForkOptions := forkOptions.value,
       Global / onLoad := onLoadSetting.value,
       webappComponentsRunnerVersion := BuildInfo.webappComponentsRunnerVersion,
       libraryDependencies ++= runnerLibraries.value


### PR DESCRIPTION
This reduces the noise caused when destroying the forked war/webapp processeses throws stream closure exceptions:

```
Exception in thread "Thread-4" java.io.IOException: Stream closed
        at java.base/java.io.BufferedInputStream.getBufIfOpen(BufferedInputStream.java:176)
        at java.base/java.io.BufferedInputStream.read1(BufferedInputStream.java:289)
        at java.base/java.io.BufferedInputStream.read(BufferedInputStream.java:351)
        at java.base/java.io.FilterInputStream.read(FilterInputStream.java:107)
        at scala.sys.process.BasicIO$.loop$1(BasicIO.scala:238)
        at scala.sys.process.BasicIO$.transferFullyImpl(BasicIO.scala:246)
        at scala.sys.process.BasicIO$.transferFully(BasicIO.scala:227)
        at scala.sys.process.BasicIO$.$anonfun$toStdErr$1(BasicIO.scala:216)
        at scala.sys.process.BasicIO$.$anonfun$toStdErr$1$adapted(BasicIO.scala:216)
        at scala.sys.process.ProcessBuilderImpl$Simple.$anonfun$run$4(ProcessBuilderImpl.scala:83)
        at scala.sys.process.ProcessImpl$Spawn$$anon$1.run(ProcessImpl.scala:27)
```

Fixes #961 