### PR TITLE
Extract the container main class names to settings

### DIFF
--- a/src/main/scala/com/earldouglas/sbt/war/WebappComponentsRunnerPlugin.scala
+++ b/src/main/scala/com/earldouglas/sbt/war/WebappComponentsRunnerPlugin.scala
@@ -26,6 +26,8 @@ object WebappComponentsRunnerPlugin extends AutoPlugin {
       taskKey[ForkOptions]("webapp container fork options")
     lazy val webappComponentsRunnerVersion =
       settingKey[String]("webapp-components-runner version")
+    lazy val webappComponentsRunnerMainClass =
+      settingKey[String]("webapp-components-runner main class")
   }
 
   import autoImport._
@@ -93,7 +95,7 @@ object WebappComponentsRunnerPlugin extends AutoPlugin {
             Seq(
               "-cp",
               Path.makeString(runnerJars),
-              "com.earldouglas.WebappComponentsRunner",
+              webappComponentsRunnerMainClass.value,
               runnerConfigFile.value.getPath()
             )
           )
@@ -136,7 +138,8 @@ object WebappComponentsRunnerPlugin extends AutoPlugin {
       webappForkOptions := forkOptions.value,
       Global / onLoad := onLoadSetting.value,
       webappComponentsRunnerVersion := BuildInfo.webappComponentsRunnerVersion,
-      libraryDependencies ++= runnerLibraries.value
+      libraryDependencies ++= runnerLibraries.value,
+      webappComponentsRunnerMainClass := "com.earldouglas.WebappComponentsRunner"
     )
   }
 }


### PR DESCRIPTION
This creates two new hidden settings:

* `WarPackageRunnerPlugin/warMainClass`
* `WebappComponentsRunnerPlugin/webappComponentsRunnerMainClass`

These are used when forking new container processes to specify the main method of the forked JVM.

Note that for WarPackageRunnerPlugin, we dropped the `-jar` argument and converted to `-cp` so that we can specify the main class manually.  This also lets us use multiple libraries in the `War` configuration, if ever needed.