### PR TITLE
webapp-runner: 10.1.28.0 -> 10.1.31.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,7 +84,7 @@ lazy val warRunner_6_0 =
         ),
       crossPaths := false, // exclude Scala suffix from artifact names
       autoScalaLibrary := false, // exclude scala-library from dependencies
-      libraryDependencies += "com.heroku" % "webapp-runner" % "10.1.28.0"
+      libraryDependencies += "com.heroku" % "webapp-runner" % "10.1.31.0"
     )
 
 lazy val sbtWar =


### PR DESCRIPTION
📦 Updates [com.heroku:webapp-runner](https://github.com/heroku/webapp-runner) from `10.1.28.0` to `10.1.31.0`

📜 [GitHub Release Notes](https://github.com/heroku/webapp-runner/releases/tag/v10.1.31.0) - [Version Diff](https://github.com/heroku/webapp-runner/compare/v10.1.28.0...v10.1.31.0)