### PR TITLE
Make quickstart the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,12 +203,12 @@ Create a .war file with `package`:
 
 ## Commands
 
-| Key             | Notes                                                                   |
-| --------------- | ----------------------------------------------------------------------- |
-| `warStart`      | Starts a local container, serving content from the packaged .war file   |
-| `warQuickstart` | Starts a local container, serving content directly from project sources |
-| `warJoin`       | Blocks until the container shuts down                                   |
-| `warStop`       | Shuts down the container                                                |
+| Key               | Notes                                                                   |
+| ----------------- | ----------------------------------------------------------------------- |
+| `warStart`        | Starts a local container, serving content directly from project sources |
+| `warStartPackage` | Starts a local container, serving content from the packaged .war file   |
+| `warJoin`         | Blocks until the container shuts down                                   |
+| `warStop`         | Shuts down the container                                                |
 
 ### `warResources`
 
@@ -319,19 +319,18 @@ warForkOptions :=
     )
 ```
 
-### `warStart` and `warQuickstart`
+### `warStart` and `warStartPackage`
 
-To run the webapp, use `warStart`:
+To run the webapp directly from project sources, use `warStart`:
 
 ```
 > warStart
 ```
 
-To skip packaging the .war file before launching the container, use
-`warQuickstart`:
+To run the webapp from the packaged .war file, use `warStartPackage`:
 
 ```
-> warQuickstart
+> warStartPackage
 ```
 
 ### `warJoin`

--- a/src/main/scala/com/earldouglas/sbt/war/SbtWar.scala
+++ b/src/main/scala/com/earldouglas/sbt/war/SbtWar.scala
@@ -33,10 +33,10 @@ object SbtWar extends AutoPlugin {
   object autoImport {
     lazy val War = config("war").hide
     lazy val warPort = settingKey[Int]("container port")
-    lazy val warStart = taskKey[Unit]("start container")
+    lazy val warStartPackage = taskKey[Unit]("start container")
     lazy val warJoin = taskKey[Unit]("join container")
     lazy val warStop = taskKey[Unit]("stop container")
-    lazy val warQuickstart = taskKey[Unit]("quickstart container")
+    lazy val warStart = taskKey[Unit]("quickstart container")
     lazy val warForkOptions =
       taskKey[ForkOptions]("container fork options")
   }
@@ -71,7 +71,7 @@ object SbtWar extends AutoPlugin {
           .toList
       }
 
-    val startWar: Initialize[Task[Unit]] =
+    val startWarFromPackage: Initialize[Task[Unit]] =
       Def.task {
 
         val runnerConfigFile: File = {
@@ -142,7 +142,7 @@ object SbtWar extends AutoPlugin {
         "com.earldouglas" % s"war-runner" % warRunnerVersion % War
       }
 
-    val quickstartWar: Initialize[Task[Unit]] =
+    val startWarFromSources: Initialize[Task[Unit]] =
       Def.task {
 
         val runnerConfigFile: File = {
@@ -195,8 +195,8 @@ object SbtWar extends AutoPlugin {
       warForkOptions := forkOptions.value,
       warJoin := joinWar.value,
       warPort := 8080,
-      warQuickstart := quickstartWar.value,
-      warStart := startWar.value,
+      warStart := startWarFromSources.value,
+      warStartPackage := startWarFromPackage.value,
       warStop := stopWar.value
     )
   }

--- a/src/sbt-test/plugins/sbt-war/test
+++ b/src/sbt-test/plugins/sbt-war/test
@@ -1,13 +1,13 @@
 > setup
 > reload
 
-> warQuickstart
+> warStart
 > awaitOpen
 > check
 > warStop
 > awaitClosed
 
-> warStart
+> warStartPackage
 > awaitOpen
 > check
 > warStop


### PR DESCRIPTION
For better ergonomics, this makes the following changes:

* Rename `warStart` to `warStartPackage`
* Rename `warQuickstart` to `warStart`

Closes #1007