### PR TITLE
Set warStart, warClasses, and warLib per configuration

### DIFF
--- a/src/main/scala/com/earldouglas/sbt/war/WarPackagePlugin.scala
+++ b/src/main/scala/com/earldouglas/sbt/war/WarPackagePlugin.scala
@@ -23,7 +23,8 @@ object WarPackagePlugin extends AutoPlugin {
 
     // Flip warContents around from (dst -> src) to (src -> dst)
     val packageContents: Initialize[Task[Seq[(java.io.File, String)]]] =
-      WebappComponentsPlugin.warContents
+      WebappComponentsPlugin
+        .warContents(Runtime)
         .map(_.map(_.swap).toSeq)
 
     val packageTaskSettings: Seq[Setting[_]] =

--- a/src/sbt-test/plugins/sbt-war/test
+++ b/src/sbt-test/plugins/sbt-war/test
@@ -1,14 +1,38 @@
 > setup
 > reload
 
+-> check
+-> checkTest-200
+-> checkTest-404
+
 > warStart
 > awaitOpen
 > check
+-> checkTest-200
+> checkTest-404
 > warStop
 > awaitClosed
+
+-> check
+-> checkTest-200
+-> checkTest-404
+
+> Test / warStart
+> awaitOpen
+> check
+> checkTest-200
+-> checkTest-404
+> warStop
+> awaitClosed
+
+-> check
+-> checkTest-
+-> checkTest-404
 
 > warStartPackage
 > awaitOpen
 > check
+-> checkTest-200
+> checkTest-404
 > warStop
 > awaitClosed

--- a/src/sbt-test/plugins/webapp-components/sbt/test.sbt
+++ b/src/sbt-test/plugins/webapp-components/sbt/test.sbt
@@ -75,7 +75,7 @@ val checkClasses: Def.Initialize[Task[Unit]] =
           .map(x => s"WEB-INF/classes/${x}" -> root / x)
           .toMap
       },
-      obtained = warClasses.value
+      obtained = (Runtime / warClasses).value
     )
   }
 
@@ -128,7 +128,7 @@ val checkLib: Def.Initialize[Task[Unit]] =
     assertContains(
       name = "WebappComponentsPlugin: checkLib",
       expected = expected.map(x => s"WEB-INF/lib/${x}"),
-      obtained = warLib.value
+      obtained = (Runtime / warLib).value
     )
   }
 
@@ -149,7 +149,7 @@ lazy val checkResources: Def.Initialize[Task[Unit]] =
       if (sizesDoNotMatch || mappingsDoNotMatch) {
         log.error(name)
         sys.error(
-          s"""|${name}:
+          s"""|${name}
               |  expected:
               |${expected.mkString("    - ", "\n    - ", "")}
               |  obtained:
@@ -178,6 +178,6 @@ lazy val checkResources: Def.Initialize[Task[Unit]] =
           .map(x => x -> root / "webapp" / x)
           .toMap
       },
-      obtained = warResources.value
+      obtained = (Runtime / warResources).value
     )
   }

--- a/src/template/src/test/scala/04-runners/servlet.scala
+++ b/src/template/src/test/scala/04-runners/servlet.scala
@@ -1,0 +1,19 @@
+package runners
+
+import com.typesafe.scalalogging.LazyLogging
+import jakarta.servlet.annotation.WebServlet
+import jakarta.servlet.http.HttpServlet
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+
+@WebServlet(urlPatterns = Array("/test"))
+class TestServlet extends HttpServlet with LazyLogging:
+
+  override def doGet(
+      request: HttpServletRequest,
+      response: HttpServletResponse
+  ): Unit =
+    logger.info("doGet")
+    response.setCharacterEncoding("UTF-8")
+    response.setContentType("text/html")
+    response.getWriter.write("""<h1>Testing!</h1>""")


### PR DESCRIPTION
This allows different sets of classes and libraries to be used with different configurations:

```
> Runtime / warStart
> Test / warStart
```

When omitted, the `Runtime` configuration is used:

```
> warStart
```